### PR TITLE
Fixes for babel-6 branch

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,20 @@
+{
+  "parser": "babel-eslint",
+  "plugins": [
+    "react"
+  ],
+  "extends": "eslint:recommended",
+  "rules": {
+    "strict": 0,
+    "curly": [1, "multi-line"],
+    "camelcase": 0,
+    "comma-dangle": 1,
+    "no-use-before-define": [1, "nofunc"],
+    "no-underscore-dangle": 0,
+    "no-unused-vars": 0,
+    "semi": 1
+  },
+  env: {
+    "node": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
+  - "5"
+  - "4.2"
   - "iojs-2"
-  - "0.10"
   - "0.12"
+  - "0.10"
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -16,8 +16,11 @@
   "devDependencies": {
     "babel-cli": "^6.2.0",
     "babel-core": "^6.2.1",
+    "babel-eslint": "^4.1.6",
     "babel-preset-es2015": "^6.1.18",
     "babel-register": "^6.2.0",
+    "eslint": "^1.10.3",
+    "eslint-plugin-react": "^3.11.2",
     "mocha": "^2.2.5",
     "rimraf": "^2.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -40,5 +40,7 @@
     "reactjs",
     "components"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "array-find": "^1.0.0"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -66,11 +66,6 @@ export default function({ types: t, template }) {
     return t.objectExpression(properties);
   }
 
-  function classDeclarationToClassExpression(node) {
-    if (t.isClassDeclaration(node)) node.type = 'ClassExpression';
-    return node;
-  }
-
   const wrapperFunctionTemplate = template(`
     function WRAPPER_FUNCTION_ID(ID_PARAM) {
       return function(COMPONENT_PARAM) {
@@ -104,13 +99,13 @@ export default function({ types: t, template }) {
       });
 
       // Can't wrap ClassDeclarations
-      let wasClassDeclaration = t.isClassDeclaration(path.node);
-      let expression = classDeclarationToClassExpression(path.node);
+      const isStatement = t.isStatement(path.node);
+      const expression = t.toExpression(path.node);
 
       // wrapperFunction("componentId")(node)
       let wrapped = wrapComponent(expression, componentId, this.wrapperFunctionId);
 
-      if (wasClassDeclaration) {
+      if (isStatement) {
         // wrapperFunction("componentId")(class Foo ...) => const Foo = wrapperFunction("componentId")(class Foo ...)
         wrapped = t.variableDeclaration('const', [
           t.variableDeclarator(

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ export default function({ types: t, template }) {
   }
 
   function classDeclarationToClassExpression(node) {
-    if (t.isClassDeclaration) node.type = 'ClassExpression';
+    if (t.isClassDeclaration(node)) node.type = 'ClassExpression';
     return node;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import find from 'array-find';
+
 export default function({ types: t, template }) {
   let _uniqueComponentId = 0;
 
@@ -6,7 +8,7 @@ export default function({ types: t, template }) {
   }
 
   function matchesPatterns(path, patterns) {
-    return !!patterns.find(pattern => {
+    return !!find(patterns, pattern => {
       return (
         t.isIdentifier(path.node, { name: pattern }) ||
         path.matchesPattern(pattern)
@@ -15,7 +17,7 @@ export default function({ types: t, template }) {
   }
 
   function isReactLikeClass(node) {
-    return !!node.body.body.find(classMember => {
+    return !!find(node.body.body, classMember => {
       return (
         t.isClassMethod(classMember) &&
         t.isIdentifier(classMember.key, { name: 'render' })
@@ -24,7 +26,7 @@ export default function({ types: t, template }) {
   }
 
   function isReactLikeComponentObject(node) {
-    return t.isObjectExpression(node) && !!node.properties.find(objectMember => {
+    return t.isObjectExpression(node) && !!find(node.properties, objectMember => {
       return (
         t.isObjectProperty(objectMember) ||
         t.isObjectMethod(objectMember)
@@ -37,7 +39,7 @@ export default function({ types: t, template }) {
 
   // `foo({ displayName: 'NAME' });` => 'NAME'
   function getDisplayName(node) {
-    const property = node.arguments[0].properties.find(node => node.key.name === 'displayName');
+    const property = find(node.arguments[0].properties, node => node.key.name === 'displayName');
     return property && property.value.value;
   }
 

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "globals": {
+    "React": false,
+    "factory": false
+  }
+}


### PR DESCRIPTION
Hey @thejameskyle - react-transform is the only blocker for moving to babel 6 in my project, so I wanted to help move this forward.

Passes tests for me on node v4.2.1.

This contains:
- .travis.yml updates for new node versions
- .eslintrcs and deps
- Fix for Array#find (use array-find module)
- A fix for failing tests caused by ClassDeclarations not being wrappable in a CallExpression.

Not sure if the way I fixed the last issue was the "right" way to do it - you probably know better - but all tests are green.
